### PR TITLE
line breaks characters are removed from commit hash

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -92,7 +92,7 @@ class Controller {
         logger.logOutput();
 
         const info = await utils.getZigbee2MQTTVersion();
-        logger.info(`Starting Zigbee2MQTT version ${info.version} (commit #${info.commitHash})`);
+        logger.info(`Starting Zigbee2MQTT version ${info.version} (commit #${info.commitHash.replace(/[\n\r]/g,"")})`);
 
         // Start zigbee
         let startResult;


### PR DESCRIPTION
Hello,

This simple change removes \r & \n characters from the commit hash. I don't know how they ended there but this makes sure that even if they do, they are removed before logging.
Before the change:
![obraz](https://user-images.githubusercontent.com/68441479/143786366-363d13f2-1341-429d-b48b-54e544acbc42.png)
After the change:
![obraz](https://user-images.githubusercontent.com/68441479/143786375-07bd824d-420b-49d3-b3ed-8ded13749097.png)

This would cause some syslog servers freak out and treat all logs as one message.
Possible relation to #9872 